### PR TITLE
Fix - recipe params need to be included in update action

### DIFF
--- a/app/controllers/api/recipes_controller.rb
+++ b/app/controllers/api/recipes_controller.rb
@@ -1,5 +1,5 @@
 class Api::RecipesController < ApplicationController
-  before_action :validate_params_presence, only: [:create]
+  before_action :validate_params_presence, only: %i[create update]
   rescue_from ActiveRecord::RecordNotFound, with: :render_404_error
 
   def index
@@ -39,6 +39,7 @@ class Api::RecipesController < ApplicationController
 
   def update
     recipe = Recipe.find(params[:id])
+    recipe.update(recipe_params)
     render json: { message: 'Your recipe was updated.' }
   end
 

--- a/app/controllers/api/recipes_controller.rb
+++ b/app/controllers/api/recipes_controller.rb
@@ -1,5 +1,6 @@
 class Api::RecipesController < ApplicationController
   before_action :validate_params_presence, only: %i[create update]
+  before_action :find_recipe, only: %i[show destroy update]
   rescue_from ActiveRecord::RecordNotFound, with: :render_404_error
 
   def index
@@ -23,23 +24,18 @@ class Api::RecipesController < ApplicationController
   end
 
   def show
-    recipe = Recipe.find(params['id'])
-    render json: recipe, serializer: Recipe::ShowSerializer
+    render json: @recipe, serializer: Recipe::ShowSerializer
   rescue ActiveRecord::RecordNotFound => e
     render_message('Recipe not found', 404)
   end
 
   def destroy
-    recipe = Recipe.find(params['id'])
-    recipe.destroy
+    @recipe.destroy
     render_message('You successfully deleted recipe', 202)
-  rescue ActiveRecord::RecordNotFound => e
-    render_message('Your request can not be processed at this time', 422)
   end
 
   def update
-    recipe = Recipe.find(params[:id])
-    recipe.update(recipe_params)
+    @recipe.update(recipe_params)
     render json: { message: 'Your recipe was updated.' }
   end
 
@@ -55,6 +51,10 @@ class Api::RecipesController < ApplicationController
     elsif params[:recipe][:ingredients_attributes].nil?
       render_message("Ingredients can't be blank", 422)
     end
+  end
+
+  def find_recipe
+    @recipe = Recipe.find(params[:id])
   end
 
   def recipe_params

--- a/spec/requests/recipes/delete_spec.rb
+++ b/spec/requests/recipes/delete_spec.rb
@@ -20,11 +20,11 @@ RSpec.describe 'DELETE /api/recipes', type: :request do
     before { delete '/api/recipes/non_exisiting_recipe' }
 
     it 'is expected to respond with status 422' do
-      expect(response.status).to eq 422
+      expect(response.status).to eq 404
     end
 
     it 'is expected to return an error message' do
-      expect(response_json['message']).to eq('Your request can not be processed at this time')
+      expect(response_json['message']).to eq('Recipe not found')
     end
   end
 end

--- a/spec/requests/recipes/update_spec.rb
+++ b/spec/requests/recipes/update_spec.rb
@@ -5,7 +5,14 @@ RSpec.describe 'PUT /api/recipes/:id', type: :request do
 
   describe 'successfully' do
     before do
-      put "/api/recipes/#{recipe.id}", params: { recipe: { title: 'Improved recipe' } }
+      put "/api/recipes/#{recipe.id}", params: {
+        recipe: {
+          title: 'new recipe',
+          ingredients_attributes: [{  amount: 10, unit: 'grams', name: 'sugar' },
+                                   { amount: 500, unit: 'grams', name: 'chocolate' }],
+          instructions_attributes: [{ instruction: 'mix together' }, { instruction: 'bake 20 min' }]
+        }
+      }
     end
 
     it { is_expected.to have_http_status 200 }
@@ -13,18 +20,43 @@ RSpec.describe 'PUT /api/recipes/:id', type: :request do
     it 'is expected to responde with a message' do
       expect(response_json['message']).to eq 'Your recipe was updated.'
     end
+
+    it 'is expected to create an instance of Recipe' do
+      expect(Recipe.last.title).to eq 'new recipe'
+    end
   end
 
   describe 'unsuccessfully' do
     describe 'with non-existent id' do
       before do
-        put '/api/recipes/9999999', params: { recipe: { title: 'My new recipie' } }
+        put '/api/recipes/9999999', params: { recipe: {
+          title: 'new recipe',
+          ingredients_attributes: [{  amount: 10, unit: 'grams', name: 'sugar' },
+                                   { amount: 500, unit: 'grams', name: 'chocolate' }],
+          instructions_attributes: [{ instruction: 'mix together' }, { instruction: 'bake 20 min' }]
+        } }
       end
 
       it { is_expected.to have_http_status 404 }
 
       it 'is expected to respond with error message' do
         expect(response_json['message']).to eq 'Recipe not found'
+      end
+    end
+
+    describe 'due to missing title' do
+      before do
+        put "/api/recipes/#{recipe.id}", params: { recipe: {
+          ingredients_attributes: [{  amount: 10, unit: 'grams', name: 'sugar' },
+                                   { amount: 500, unit: 'grams', name: 'chocolate' }],
+          instructions_attributes: [{ instruction: 'mix together' }, { instruction: 'bake 20 min' }]
+        } }
+      end
+
+      it { is_expected.to have_http_status 422 }
+
+      it 'is expected to respond with an error message' do
+        expect(response_json['message']).to eq "Title can't be blank"
       end
     end
   end


### PR DESCRIPTION
### This PR contains:

- include recipe params in update action
- validate param presence in update action
- refactor code to find recipe by id in before action
- change delete spec

[PT story](https://www.pivotaltracker.com/story/show/181535199)