### PR TITLE
Bug - instructions are duplicated after update action

### DIFF
--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -5,7 +5,7 @@ class Recipe < ApplicationRecord
   has_many :instructions
   has_many :ingredients
   has_one_attached :image
-  accepts_nested_attributes_for :instructions, :ingredients
+  accepts_nested_attributes_for :instructions, :ingredients, allow_destroy: true
 
   def image_serialized
     if !image.attached?

--- a/spec/requests/recipes/update_spec.rb
+++ b/spec/requests/recipes/update_spec.rb
@@ -56,8 +56,8 @@ RSpec.describe 'PUT /api/recipes/:id', type: :request do
         { instruction: i.instruction }
       end
       expect(instructions).to eq [
-        { instruction: 'bake 20 min' },
-        { instruction: 'mix together' }
+        { instruction: 'mix together' },
+        { instruction: 'bake 20 min' }
       ]
     end
   end

--- a/spec/requests/recipes/update_spec.rb
+++ b/spec/requests/recipes/update_spec.rb
@@ -56,8 +56,8 @@ RSpec.describe 'PUT /api/recipes/:id', type: :request do
         { instruction: i.instruction }
       end
       expect(instructions).to eq [
-        { instruction: 'mix together' },
-        { instruction: 'bake 20 min' }
+        { instruction: 'bake 20 min' },
+        { instruction: 'mix together' }
       ]
     end
   end

--- a/spec/requests/recipes/update_spec.rb
+++ b/spec/requests/recipes/update_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe 'PUT /api/recipes/:id', type: :request do
           ingredients_attributes: [{ id: ingredient1.id, amount: 100, unit: 'ml', name: 'milk' },
                                    { amount: 10, unit: 'grams', name: 'sugar' },
                                    { amount: 500, unit: 'grams', name: 'chocolate' }],
-          instructions_attributes: [{ instruction: 'mix together' },
-                                    { instruction: 'bake 20 min' },
-                                    { id: instruction1.id, _destroy: true }]
+          instructions_attributes: [{ id: instruction1.id, _destroy: true },
+                                    { instruction: 'mix together' },
+                                    { instruction: 'bake 20 min' }]
         }
       }
     end

--- a/spec/requests/recipes/update_spec.rb
+++ b/spec/requests/recipes/update_spec.rb
@@ -23,8 +23,9 @@ RSpec.describe 'PUT /api/recipes/:id', type: :request do
           ingredients_attributes: [{ id: ingredient1.id, amount: 100, unit: 'ml', name: 'milk' },
                                    { amount: 10, unit: 'grams', name: 'sugar' },
                                    { amount: 500, unit: 'grams', name: 'chocolate' }],
-          instructions_attributes: [{ id: instruction1.id, instruction: 'mix together' },
-                                    { instruction: 'bake 20 min' }]
+          instructions_attributes: [{ instruction: 'mix together' },
+                                    { instruction: 'bake 20 min' },
+                                    { id: instruction1.id, _destroy: true }]
         }
       }
     end
@@ -35,11 +36,11 @@ RSpec.describe 'PUT /api/recipes/:id', type: :request do
       expect(response_json['message']).to eq 'Your recipe was updated.'
     end
 
-    it 'is expected to create an instance of Recipe' do
+    it 'is expected to update an instance of Recipe' do
       expect(Recipe.last.title).to eq 'new recipe'
     end
 
-    it 'is expected to create an instance of Recipe with right ingredients' do
+    it 'is expected to update an instance of Recipe with right ingredients' do
       ingredients = Recipe.last.ingredients.map do |i|
         { amount: i.amount, unit: i.unit, name: i.name }
       end
@@ -50,7 +51,7 @@ RSpec.describe 'PUT /api/recipes/:id', type: :request do
       ]
     end
 
-    it 'is expected to create an instance of Recipe with right instructions' do
+    it 'is expected to update an instance of Recipe with right instructions' do
       instructions = Recipe.last.instructions.map do |i|
         { instruction: i.instruction }
       end


### PR DESCRIPTION
### This PR contains:

- add allow destroy true to delete original values of instructions and replace with new values

https://www.pivotaltracker.com/story/show/182085234