### PR TITLE
Api provides possibility to delete an ingredient

### DIFF
--- a/app/controllers/api/recipes_controller.rb
+++ b/app/controllers/api/recipes_controller.rb
@@ -65,7 +65,7 @@ class Api::RecipesController < ApplicationController
     params[:recipe].permit(
       :title,
       instructions_attributes: %i[id instruction _destroy],
-      ingredients_attributes: %i[id amount unit name]
+      ingredients_attributes: %i[id amount unit name _destroy]
     )
   end
 

--- a/spec/requests/recipes/create_spec.rb
+++ b/spec/requests/recipes/create_spec.rb
@@ -7,7 +7,7 @@ describe 'POST /api/recipes', type: :request do
            params: {
              recipe: {
                title: 'nom nom',
-               ingredients_attributes: [{  amount: 100, unit: 'grams', name: 'sugar' },
+               ingredients_attributes: [{  amount: 100, unit: 'grams', name: 'sugar', _destroy: true },
                                         { amount: 500, unit: 'grams', name: 'chocolate' }],
                instructions_attributes: [{ instruction: 'mix together' }, { instruction: 'bake' }],
                image: 'data:image/image/png;base64,iVBORw0KGgoAAAANSUhEUgAAASwAAAEBCAMAAAD1kWivAAADAFB'
@@ -32,6 +32,15 @@ describe 'POST /api/recipes', type: :request do
 
     it 'is expected to return aproval message that recipe was created' do
       expect(response_json['message']).to eq 'Recipe was created successfully'
+    end
+
+    it 'is expected to delete ingredient that has destroy attribute' do
+      ingredients = @recipe.ingredients.map do |i|
+        { amount: i.amount, unit: i.unit, name: i.name }
+      end
+      expect(ingredients).to eq [
+        { amount: 500, unit: 'grams', name: 'chocolate' }
+      ]
     end
   end
 

--- a/spec/requests/recipes/update_spec.rb
+++ b/spec/requests/recipes/update_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe 'PUT /api/recipes/:id', type: :request do
         recipe: {
           title: 'new recipe',
           ingredients_attributes: [
-            { id: ingredient1.id, amount: 100, unit: 'ml', name: 'milk' },
-            { amount: 10, unit: 'grams', name: 'sugar' },
+            { id: ingredient1.id, amount: 100, unit: 'ml', name: 'milk', _destroy: true },
+            { amount: 10, unit: 'grams', name: 'sugar', _destroy: true },
             { amount: 500, unit: 'grams', name: 'chocolate' }
           ],
           instructions_attributes: [
@@ -61,8 +61,6 @@ RSpec.describe 'PUT /api/recipes/:id', type: :request do
         { amount: i.amount, unit: i.unit, name: i.name }
       end
       expect(ingredients).to eq [
-        { amount: 100, unit: 'ml', name: 'milk' },
-        { amount: 10, unit: 'grams', name: 'sugar' },
         { amount: 500, unit: 'grams', name: 'chocolate' }
       ]
     end


### PR DESCRIPTION
### This PR contains:

- add _destroy : true param to ingredients in update spec
- add _destroy : true param to ingredients in create spec
- add _destroy as permitted params for ingredients in recipe_params

[PT story](https://www.pivotaltracker.com/story/show/182341639)